### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ django-pesapal
 .. image:: https://coveralls.io/repos/odero/django-pesapal/badge.png?branch=master
    :target: https://coveralls.io/r/odero/django-pesapal?branch=master
 
-.. image:: https://pypip.in/status/django-pesapal/badge.svg
+.. image:: https://img.shields.io/pypi/status/django-pesapal.svg
    :target: https://pypi.python.org/pypi/django-pesapal/
    :alt: Development Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-pesapal))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-pesapal`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.